### PR TITLE
Adding CARGO_MANIFEST_DIR to make paths consistent

### DIFF
--- a/templates/tests/template.rs
+++ b/templates/tests/template.rs
@@ -2,16 +2,16 @@
 
 fluent_templates::static_loader! {
     static LOCALES = {
-        locales: "./templates/tests/locales",
+        locales: "./tests/locales",
         fallback_language: "en-US",
-        core_locales: "./templates/tests/locales/core.ftl",
+        core_locales: "./tests/locales/core.ftl",
         customise: |bundle| bundle.set_use_isolating(false),
     };
 }
 
 fluent_templates::static_loader! {
     pub(crate) static _LOCALES = {
-        locales: "./templates/tests/locales",
+        locales: "./tests/locales",
         fallback_language: "en-US"
     };
 }


### PR DESCRIPTION
Fixes #3 

Problem: When a crate is in a workspace, the current directory may not always be the root of the workspace depending on what cargo task is running. As the #3 showed, `cargo test --doc` appears to run with the current directory set to the crate itself, whereas when running the rest of the cargo suite, the current working directory is set to the workspace root.

Solution: Cargo provides CARGO_MANIFEST_DIR to locate the directory that contains Cargo.toml for the currently compiling crate. This patch uses it to resolve core_locales and locales_directory.