### PR TITLE
Fixes #10 -- Handlebars example from the docs appears not to compile

### DIFF
--- a/templates/src/lib.rs
+++ b/templates/src/lib.rs
@@ -170,6 +170,10 @@
 //! automatically convert argument keys from Tera's `snake_case` to the fluent's
 //! preferred `kebab-case` arguments.
 //!
+//! ```toml
+//!fluent-templates = { version = "*", features = ["tera"] }
+//!```
+//!
 //! ```rust
 //! use fluent_templates::{FluentLoader, static_loader};
 //!
@@ -203,6 +207,10 @@
 //! ### Handlebars
 //! In handlebars, `fluent-templates` will read the `lang` field in your
 //! [`handlebars::Context`] while rendering.
+//!
+//! ```toml
+//!fluent-templates = { version = "*", features = ["handlebars"] }
+//!```
 //!
 //! ```rust
 //! use fluent_templates::{FluentLoader, static_loader};


### PR DESCRIPTION
Port info on templating language features from README to documentation. This will help new users catch the need to enable these features and avoid user error.