### PR TITLE
Fallback to default when requested language is missing, rather than panicking

### DIFF
--- a/templates/src/loader/arc_loader.rs
+++ b/templates/src/loader/arc_loader.rs
@@ -109,9 +109,11 @@ impl super::Loader for ArcLoader {
         text_id: &str,
         args: Option<&HashMap<String, FluentValue>>,
     ) -> String {
-        for l in self.fallbacks.get(lang).expect("language not found") {
-            if let Some(val) = self.lookup_single_language(l, text_id, args) {
-                return val;
+        if let Some(fallbacks) = self.fallbacks.get(lang) {
+            for l in fallbacks {
+                if let Some(val) = self.lookup_single_language(l, text_id, args) {
+                    return val;
+                }
             }
         }
         if *lang != self.fallback {
@@ -168,7 +170,7 @@ impl ArcLoader {
                 None
             }
         } else {
-            panic!("Unknown language {}", lang)
+            None
         }
     }
 }

--- a/templates/src/loader/static_loader.rs
+++ b/templates/src/loader/static_loader.rs
@@ -69,9 +69,11 @@ impl StaticLoader {
         text_id: &str,
         args: Option<&HashMap<String, FluentValue>>,
     ) -> Option<String> {
-        for l in self.fallbacks.get(lang).expect("language not found") {
-            if let Some(val) = self.lookup_single_language(l, text_id, args) {
-                return Some(val);
+        if let Some(fallbacks) = self.fallbacks.get(lang) {
+            for l in fallbacks {
+                if let Some(val) = self.lookup_single_language(l, text_id, args) {
+                    return Some(val);
+                }
             }
         }
 
@@ -87,9 +89,11 @@ impl super::Loader for StaticLoader {
         text_id: &str,
         args: Option<&HashMap<String, FluentValue>>,
     ) -> String {
-        for l in self.fallbacks.get(lang).expect("language not found") {
-            if let Some(val) = self.lookup_single_language(l, text_id, args) {
-                return val;
+        if let Some(fallbacks) = self.fallbacks.get(lang) {
+            for l in fallbacks {
+                if let Some(val) = self.lookup_single_language(l, text_id, args) {
+                    return val;
+                }
             }
         }
         if *lang != self.fallback {


### PR DESCRIPTION
I'm fairly new to fluent, and in my application I'm setting the requested language id from the user's locale settings, but there's only the one localization at the moment, and it doesn't seem right to have the application panic at runtime if the user's locale differs from the fallback locale.

At the very least I think it should return an error rather than panic, so that it's recoverable, but it seems to me that the requested language not being available is also a situation where the fallback language should be used.

#15 also would help with avoiding the panic, but I think that for most situations it would be sufficient just to use the fallback language, and simpler from the perspective of using the library.