### PR TITLE
Add function that returns available locales

### DIFF
--- a/templates/src/loader.rs
+++ b/templates/src/loader.rs
@@ -46,6 +46,9 @@ pub trait Loader {
         text_id: &str,
         args: Option<&HashMap<String, FluentValue>>,
     ) -> String;
+
+    /// Returns an Iterator over the locales that are present.
+    fn locales(&self) -> Box<dyn Iterator<Item = &LanguageIdentifier> + '_>;
 }
 
 impl<L> Loader for std::sync::Arc<L>
@@ -60,6 +63,10 @@ where
     ) -> String {
         L::lookup_complete(self, lang, text_id, args)
     }
+
+    fn locales(&self) -> Box<dyn Iterator<Item = &LanguageIdentifier> + '_> {
+        L::locales(self)
+    }
 }
 
 impl<'a, L> Loader for &'a L
@@ -73,6 +80,10 @@ where
         args: Option<&HashMap<String, FluentValue>>,
     ) -> String {
         L::lookup_complete(self, lang, text_id, args)
+    }
+
+    fn locales(&self) -> Box<dyn Iterator<Item = &LanguageIdentifier> + '_> {
+        L::locales(self)
     }
 }
 

--- a/templates/src/loader/arc_loader.rs
+++ b/templates/src/loader/arc_loader.rs
@@ -123,6 +123,10 @@ impl super::Loader for ArcLoader {
         }
         format!("Unknown localization {}", text_id)
     }
+
+    fn locales(&self) -> Box<dyn Iterator<Item=&LanguageIdentifier> + '_> {
+        Box::new(self.fallbacks.keys())
+    }
 }
 
 impl ArcLoader {
@@ -139,10 +143,6 @@ impl ArcLoader {
         }
     }
 
-    /// Returns a Vec over the locales that were detected.
-    pub fn locales(&self) -> Vec<LanguageIdentifier> {
-        self.resources.keys().cloned().collect()
-    }
 
     /// Convenience function to look up a string for a single language
     pub fn lookup_single_language(

--- a/templates/src/loader/static_loader.rs
+++ b/templates/src/loader/static_loader.rs
@@ -103,4 +103,8 @@ impl super::Loader for StaticLoader {
         }
         format!("Unknown localization {}", text_id)
     }
+
+    fn locales(&self) -> Box<dyn Iterator<Item=&LanguageIdentifier> + '_> {
+        Box::new(self.fallbacks.keys())
+    }
 }


### PR DESCRIPTION
This extends the Loader trait
Fixes https://github.com/XAMPPRocky/fluent-templates/issues/15

I think returning iterator is more lightweight solution than the vector. The only drawback is that I return Boxed object due to the polymorphic nature of the iterator.
It is also should be possible to avoid boxing by adding the associated type to the trait. However, I couldn't get the lifetimes right in my first try, so are you happy with Box?