### PR TITLE
Fix compile error with flume 0.7.2

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -21,5 +21,5 @@ syn = { version = "1.0.30", features = ["full"] }
 proc-macro2 = "1.0.18"
 once_cell = "1.4.0"
 ignore = "0.4.16"
-flume = "0.7.1"
+flume = "0.7.2"
 unic-langid = "0.9.0"

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -121,9 +121,9 @@ fn build_resources(dir: impl AsRef<std::path::Path>) -> HashMap<String, Vec<Stri
 pub(crate) fn read_from_dir<P: AsRef<Path>>(path: P) -> Vec<String> {
     let (tx, rx) = flume::unbounded();
 
-    WalkBuilder::new(path).build_parallel().run(|| {
-        Box::new(|result| {
-            let tx = tx.clone();
+    WalkBuilder::new(path).build_parallel().run( || {
+        let tx = tx.clone();
+        Box::new(move |result| {
             if let Ok(entry) = result {
                 if entry
                     .file_type()

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -121,7 +121,7 @@ fn build_resources(dir: impl AsRef<std::path::Path>) -> HashMap<String, Vec<Stri
 pub(crate) fn read_from_dir<P: AsRef<Path>>(path: P) -> Vec<String> {
     let (tx, rx) = flume::unbounded();
 
-    WalkBuilder::new(path).build_parallel().run( || {
+    WalkBuilder::new(path).build_parallel().run(|| {
         let tx = tx.clone();
         Box::new(move |result| {
             if let Ok(entry) = result {

--- a/templates/Cargo.toml
+++ b/templates/Cargo.toml
@@ -32,7 +32,7 @@ snafu = "0.6.6"
 tera = { version = "1.2.0", optional = true }
 heck = "0.3.1"
 ignore = "0.4.16"
-flume = "0.7.1"
+flume = "0.7.2"
 log = "0.4.8"
 fluent-template-macros = { path = "../macros", optional = true, version = "=0.5.9" }
 once_cell = "1.4.0"

--- a/templates/src/fs.rs
+++ b/templates/src/fs.rs
@@ -33,8 +33,8 @@ pub(crate) fn read_from_dir<P: AsRef<Path>>(path: P) -> crate::Result<Vec<Fluent
     let (tx, rx) = flume::unbounded();
 
     WalkBuilder::new(path).build_parallel().run(|| {
-        Box::new(|result| {
-            let tx = tx.clone();
+        let tx = tx.clone();
+        Box::new(move |result| {
             if let Ok(entry) = result {
                 if entry
                     .file_type()


### PR DESCRIPTION
The Sender should be first cloned and then moved to the worker thread.
Otherwise the Sender requires to be `Sync`,
which is not needed for mpsc.

I am not sure whether I should bump version in Cargo.toml. On my local machine it didn't want to update.