### PR TITLE
Loader::lookup/lookup_complete/lookup_with_args return Option<String>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,9 +150,9 @@
 //! }
 //!
 //! fn main() {
-//!     assert_eq!("Hello World!", LOCALES.lookup(&US_ENGLISH, "hello-world"));
-//!     assert_eq!("Bonjour le monde!", LOCALES.lookup(&FRENCH, "hello-world"));
-//!     assert_eq!("Hallo Welt!", LOCALES.lookup(&GERMAN, "hello-world"));
+//!     assert_eq!("Hello World!", LOCALES.lookup(&US_ENGLISH, "hello-world").unwrap());
+//!     assert_eq!("Bonjour le monde!", LOCALES.lookup(&FRENCH, "hello-world").unwrap());
+//!     assert_eq!("Hallo Welt!", LOCALES.lookup(&GERMAN, "hello-world").unwrap());
 //!
 //!     let args = {
 //!         let mut map = HashMap::new();
@@ -160,12 +160,12 @@
 //!         map
 //!     };
 //!
-//!     assert_eq!("Hello Friend!", LOCALES.lookup(&US_ENGLISH, "greeting.placeholder"));
-//!     assert_eq!("Hello Alice!", LOCALES.lookup_with_args(&US_ENGLISH, "greeting", &args));
-//!     assert_eq!("Salut l'ami!", LOCALES.lookup(&FRENCH, "greeting.placeholder"));
-//!     assert_eq!("Bonjour Alice!", LOCALES.lookup_with_args(&FRENCH, "greeting", &args));
-//!     assert_eq!("Hallo Fruend!", LOCALES.lookup(&GERMAN, "greeting.placeholder"));
-//!     assert_eq!("Hallo Alice!", LOCALES.lookup_with_args(&GERMAN, "greeting", &args));
+//!     assert_eq!("Hello Friend!", LOCALES.lookup(&US_ENGLISH, "greeting.placeholder").unwrap());
+//!     assert_eq!("Hello Alice!", LOCALES.lookup_with_args(&US_ENGLISH, "greeting", &args).unwrap());
+//!     assert_eq!("Salut l'ami!", LOCALES.lookup(&FRENCH, "greeting.placeholder").unwrap());
+//!     assert_eq!("Bonjour Alice!", LOCALES.lookup_with_args(&FRENCH, "greeting", &args).unwrap());
+//!     assert_eq!("Hallo Fruend!", LOCALES.lookup(&GERMAN, "greeting.placeholder").unwrap());
+//!     assert_eq!("Hallo Alice!", LOCALES.lookup_with_args(&GERMAN, "greeting", &args).unwrap());
 //!
 //!
 //!     let args = {
@@ -175,8 +175,8 @@
 //!         map
 //!     };
 //!
-//!     assert_eq!("text one 1 second 2", LOCALES.lookup_with_args(&US_ENGLISH, "parameter2", &args));
-//!     assert_eq!("texte une 1 seconde 2", LOCALES.lookup_with_args(&FRENCH, "parameter2", &args));
+//!     assert_eq!("text one 1 second 2", LOCALES.lookup_with_args(&US_ENGLISH, "parameter2", &args).unwrap());
+//!     assert_eq!("texte une 1 seconde 2", LOCALES.lookup_with_args(&FRENCH, "parameter2", &args).unwrap());
 //! }
 //! ```
 //!

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -27,7 +27,7 @@ pub use static_loader::StaticLoader;
 /// A loader capable of looking up Fluent keys given a language.
 pub trait Loader {
     /// Look up `text_id` for `lang` in Fluent.
-    fn lookup(&self, lang: &LanguageIdentifier, text_id: &str) -> String {
+    fn lookup(&self, lang: &LanguageIdentifier, text_id: &str) -> Option<String> {
         self.lookup_complete::<&str>(lang, text_id, None)
     }
 
@@ -37,7 +37,7 @@ pub trait Loader {
         lang: &LanguageIdentifier,
         text_id: &str,
         args: &HashMap<T, FluentValue>,
-    ) -> String {
+    ) -> Option<String> {
         self.lookup_complete(lang, text_id, Some(args))
     }
 
@@ -47,7 +47,7 @@ pub trait Loader {
         lang: &LanguageIdentifier,
         text_id: &str,
         args: Option<&HashMap<T, FluentValue>>,
-    ) -> String;
+    ) -> Option<String>;
 
     /// Returns an Iterator over the locales that are present.
     fn locales(&self) -> Box<dyn Iterator<Item = &LanguageIdentifier> + '_>;
@@ -62,7 +62,7 @@ where
         lang: &LanguageIdentifier,
         text_id: &str,
         args: Option<&HashMap<T, FluentValue>>,
-    ) -> String {
+    ) -> Option<String> {
         L::lookup_complete(self, lang, text_id, args)
     }
 
@@ -80,7 +80,7 @@ where
         lang: &LanguageIdentifier,
         text_id: &str,
         args: Option<&HashMap<T, FluentValue>>,
-    ) -> String {
+    ) -> Option<String> {
         L::lookup_complete(self, lang, text_id, args)
     }
 

--- a/src/loader/arc_loader.rs
+++ b/src/loader/arc_loader.rs
@@ -106,20 +106,20 @@ impl super::Loader for ArcLoader {
         lang: &LanguageIdentifier,
         text_id: &str,
         args: Option<&HashMap<T, FluentValue>>,
-    ) -> String {
+    ) -> Option<String> {
         if let Some(fallbacks) = self.fallbacks.get(lang) {
             for l in fallbacks {
                 if let Some(val) = self.lookup_single_language(l, text_id, args) {
-                    return val;
+                    return Some(val);
                 }
             }
         }
         if *lang != self.fallback {
             if let Some(val) = self.lookup_single_language(&self.fallback, text_id, args) {
-                return val;
+                return Some(val);
             }
         }
-        format!("Unknown localization {}", text_id)
+        None
     }
 
     fn locales(&self) -> Box<dyn Iterator<Item = &LanguageIdentifier> + '_> {

--- a/src/loader/handlebars.rs
+++ b/src/loader/handlebars.rs
@@ -121,6 +121,12 @@ impl<L: Loader + Send + Sync> HelperDef for FluentLoader<L> {
             .expect("Language not valid identifier");
 
         let response = self.loader.lookup_complete(&lang, &id, args.as_ref());
-        out.write(&response).map_err(|error| RenderError::from_error("Failed to write", error))
+
+        match response {
+            Some(response) => out
+                .write(&response)
+                .map_err(|error| RenderError::from_error("Failed to write", error)),
+            None => Err(RenderError::new(format!("Unknown localization {}", id))),
+        }
     }
 }

--- a/src/loader/static_loader.rs
+++ b/src/loader/static_loader.rs
@@ -62,20 +62,20 @@ impl super::Loader for StaticLoader {
         lang: &LanguageIdentifier,
         text_id: &str,
         args: Option<&HashMap<T, FluentValue>>,
-    ) -> String {
+    ) -> Option<String> {
         if let Some(fallbacks) = self.fallbacks.get(lang) {
             for l in fallbacks {
                 if let Some(val) = self.lookup_single_language(l, text_id, args) {
-                    return val;
+                    return Some(val);
                 }
             }
         }
         if *lang != self.fallback {
             if let Some(val) = self.lookup_single_language(&self.fallback, text_id, args) {
-                return val;
+                return Some(val);
             }
         }
-        format!("Unknown localization {}", text_id)
+        None
     }
 
     fn locales(&self) -> Box<dyn Iterator<Item = &LanguageIdentifier> + '_> {

--- a/src/loader/tera.rs
+++ b/src/loader/tera.rs
@@ -74,6 +74,9 @@ impl<L: Loader + Send + Sync> tera::Function for crate::FluentLoader<L> {
 
         let response = self.loader.lookup_with_args(lang, &id, &fluent_args);
 
-        Ok(Json::String(response))
+        match response {
+            Some(response) => Ok(Json::String(response)),
+            None => Err(tera::Error::msg(format!("Unknown localization {}", id))),
+        }
     }
 }


### PR DESCRIPTION
Loader::lookup/lookup_complete/lookup_with_args now return
Option\<String\> so the user can control what happens when a lookup
returns nothing.

Ref: https://github.com/XAMPPRocky/fluent-templates/issues/32