### PR TITLE
Remove flume default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ snafu = "0.7.0"
 tera = { version = "1.15.0", optional = true }
 heck = "0.4.0"
 ignore = "0.4.18"
-flume = "0.10.12"
+flume = { version = "0.10.12", default-features = false }
 log = "0.4.14"
 fluent-template-macros = { path = "./macros", optional = true, version = "0.7.0" }
 once_cell = "1.10.0"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -21,5 +21,5 @@ syn = { version = "1.0.88", features = ["full"] }
 proc-macro2 = "1.0.36"
 once_cell = "1.10.0"
 ignore = "0.4.16"
-flume = "0.10.12"
+flume = { version = "0.10.12", default-features = false }
 unic-langid = "0.9.0"


### PR DESCRIPTION
For some annoying reasons that have nothing to do with the quality of this lib, having flume as a dependency is preventing some compilations. This PR removes the default features to make sure `nanorand` doesn't get included.

The real culprit is that [`nanorand` v0.7.0 doesn't guard its `js` feature with any `cfg`](https://github.com/Absolucy/nanorand-rs/blob/0.7.0/Cargo.toml#L25), which when [used by flume (default features)](https://github.com/zesterer/flume/blob/master/Cargo.toml#L29) results in a nasty circular dependency such as:
```
 › cargo build
    Updating crates.io index
error: cyclic package dependency: package `serde_json v1.0.82` depends on itself. Cycle:
package `serde_json v1.0.82`
    ... which satisfies dependency `serde_json = "^1.0"` of package `wasm-bindgen v0.2.81`
    ... which satisfies dependency `wasm-bindgen = "^0.2.81"` of package `js-sys v0.3.58`
    ... which satisfies dependency `js-sys = "^0.3"` of package `getrandom v0.2.7`
    ... which satisfies dependency `getrandom = "^0.2.3"` of package `ahash v0.7.6`
    ... which satisfies dependency `ahash = "^0.7.0"` of package `hashbrown v0.12.2`
    ... which satisfies dependency `hashbrown = "^0.12"` of package `indexmap v1.9.1`
    ... which satisfies dependency `indexmap = "^1.5.2"` of package `serde_json v1.0.82`
    ... which satisfies dependency `serde_json = "^1.0"` of package `acme-micro v0.12.0`
```

~~This seems like the simplest solution for my immediate issue (trying to add a fluent templates example to the Actix Web [examples repo](https://github.com/actix/examples)) but given that flume is not adding any value where it is used here, it seems prudent to reduce dependencies, too.~~