### PR TITLE
Add ignore as optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,9 @@ all-features = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
-default = ["macros"]
+default = ["macros", "use-ignore"]
 macros = ["fluent-template-macros"]
+use-ignore = ["ignore", "fluent-template-macros/ignore"]
 
 [dependencies]
 handlebars = { version = "4", optional = true }
@@ -34,13 +35,14 @@ unic-langid = { version = "0.9.0", features = ["macros"] }
 snafu = "0.7.0"
 tera = { version = "1.15.0", optional = true }
 heck = "0.4.0"
-ignore = "0.4.18"
+ignore = { version = "0.4.18", optional = true }
 flume = { version = "0.10.12", default-features = false }
 log = "0.4.14"
 fluent-template-macros = { path = "./macros", optional = true, version = "0.8.0" }
 once_cell = "1.10.0"
 arc-swap = "1.5.0"
 intl-memoizer = "0.5.1"
+walkdir = { version = "2.3.3", optional = true }
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -15,11 +15,15 @@ proc-macro = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["ignore"]
+
 [dependencies]
 quote = "1.0.15"
 syn = { version = "1.0.88", features = ["full"] }
 proc-macro2 = "1.0.36"
 once_cell = "1.10.0"
-ignore = "0.4.16"
+ignore = { version = "0.4.16", optional = true }
 flume = { version = "0.10.12", default-features = false }
 unic-langid = "0.9.0"
+walkdir = { version = "2.3.3", optional = true }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -120,6 +120,9 @@ fn build_resources(dir: impl AsRef<std::path::Path>) -> HashMap<String, Vec<Stri
 pub(crate) fn read_from_dir<P: AsRef<Path>>(path: P) -> Vec<String> {
     let (tx, rx) = flume::unbounded();
 
+    #[cfg(not(any(feature = "ignore", feature = "walkdir",)))]
+    compile_error!("one of the features `ignore` or `walkdir` must be enabled.");
+
     #[cfg(feature = "ignore")]
     ignore::WalkBuilder::new(path).build_parallel().run(|| {
         let tx = tx.clone();

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -4,7 +4,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use ignore::WalkBuilder;
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{
@@ -121,7 +120,8 @@ fn build_resources(dir: impl AsRef<std::path::Path>) -> HashMap<String, Vec<Stri
 pub(crate) fn read_from_dir<P: AsRef<Path>>(path: P) -> Vec<String> {
     let (tx, rx) = flume::unbounded();
 
-    WalkBuilder::new(path).build_parallel().run(|| {
+    #[cfg(feature = "ignore")]
+    ignore::WalkBuilder::new(path).build_parallel().run(|| {
         let tx = tx.clone();
         Box::new(move |result| {
             if let Ok(entry) = result {
@@ -138,6 +138,20 @@ pub(crate) fn read_from_dir<P: AsRef<Path>>(path: P) -> Vec<String> {
             ignore::WalkState::Continue
         })
     });
+
+    #[cfg(all(not(feature = "ignore"), feature = "walkdir"))]
+    walkdir::WalkDir::new(path)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file())
+        .filter(|e| e.path().extension().map_or(false, |e| e == "ftl"))
+        .for_each(|e| {
+            if let Ok(string) = std::fs::read_to_string(e.path()) {
+                let _ = tx.send(string);
+            } else {
+                log::warn!("Couldn't read {}", e.path().display());
+            }
+        });
 
     rx.drain().collect::<Vec<_>>()
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -31,6 +31,9 @@ pub fn resources_from_vec(srcs: &[String]) -> crate::Result<Vec<FluentResource>>
 pub(crate) fn read_from_dir<P: AsRef<Path>>(path: P) -> crate::Result<Vec<FluentResource>> {
     let (tx, rx) = flume::unbounded();
 
+    #[cfg(not(any(feature = "use-ignore", feature = "walkdir",)))]
+    compile_error!("one of the features `use-ignore` or `walkdir` must be enabled.");
+
     #[cfg(feature = "use-ignore")]
     ignore::WalkBuilder::new(path).build_parallel().run(|| {
         let tx = tx.clone();

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -2,7 +2,6 @@ use std::fs;
 use std::path::Path;
 
 use fluent_bundle::FluentResource;
-use ignore::{WalkBuilder, WalkState};
 use snafu::*;
 pub use unic_langid::{langid, langids, LanguageIdentifier};
 
@@ -32,7 +31,8 @@ pub fn resources_from_vec(srcs: &[String]) -> crate::Result<Vec<FluentResource>>
 pub(crate) fn read_from_dir<P: AsRef<Path>>(path: P) -> crate::Result<Vec<FluentResource>> {
     let (tx, rx) = flume::unbounded();
 
-    WalkBuilder::new(path).build_parallel().run(|| {
+    #[cfg(feature = "use-ignore")]
+    ignore::WalkBuilder::new(path).build_parallel().run(|| {
         let tx = tx.clone();
         Box::new(move |result| {
             if let Ok(entry) = result {
@@ -50,9 +50,23 @@ pub(crate) fn read_from_dir<P: AsRef<Path>>(path: P) -> crate::Result<Vec<Fluent
                 }
             }
 
-            WalkState::Continue
+            ignore::WalkState::Continue
         })
     });
+
+    #[cfg(all(not(feature = "ignore"), feature = "walkdir"))]
+    walkdir::WalkDir::new(path)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file())
+        .filter(|e| e.path().extension().map_or(false, |e| e == "ftl"))
+        .for_each(|e| {
+            if let Ok(string) = std::fs::read_to_string(e.path()) {
+                let _ = tx.send(string);
+            } else {
+                log::warn!("Couldn't read {}", e.path().display());
+            }
+        });
 
     resources_from_vec(&rx.drain().collect::<Vec<_>>())
 }


### PR DESCRIPTION
The `ignore` crate pulls in `regex`, which adds to the binary size quite significantly. If we do not need the `.ignore` features, we can opt out of it and drop the dependency.

This PR locks the `ignore` crate behind a `use-ignore` default feature, and adds a `walkdir` optional feature. When `walkdir` is enabled, we use the `walkdir` crate to traverse the directory instead. This does not respect `.ignore` files.

If neither `use-ignore` nor `walkdir` features are enabled, a compile-time error is raised.