### PR TITLE
Sort the 'insert_resources' data to make static_loader! deterministic

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -211,7 +211,13 @@ pub fn static_loader(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
         quote!(None)
     };
 
-    let insert_resources = build_resources(locales_directory)
+    let mut insert_resources: Vec<_> = build_resources(locales_directory).into_iter().collect();
+
+    // Make the output `TokenStream` only depend on the filenames and the file contents,
+    // not hashmap/filesystem iteration order.
+    insert_resources.sort();
+
+    let insert_resources = insert_resources
         .into_iter()
         .map(|(locale, resources)| {
             quote!(


### PR DESCRIPTION
Currently, the `TokenStream` produced by the `static_loader!` macro depends on the default `HashMap` iteration order, as well as the filesystem directory iteration order.

To allow `static_loader!` to be compatible with a reproducible build, I've sorted the output of `insert_resources` before iterating over it. This ensures that the final `TokenStream` depends only on the loaded filenames and the file contents.