### PR TITLE
chore: Bump `fluent-langneg` to `v0.14` and `heck` to `v0.5.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,13 @@ description = "Templating for the Fluent localization framework"
 keywords = ["handlebars", "tera", "fluent", "internationalization", "localization"]
 categories = ["internationalization", "localization", "template-engine"]
 
+[workspace.dependencies]
+unic-langid = "0.9.0"
+ignore = "0.4.18"
+flume = { version = "0.11.0", default-features = false }
+once_cell = "1.10.0"
+walkdir = "2.3.3"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [package.metadata.docs.rs]
 all-features = true
@@ -43,18 +50,18 @@ fluent-bundle = "0.15.2"
 fluent-syntax = "0.11"
 fluent-langneg = "0.13"
 serde_json = "1.0.79"
-unic-langid = { version = "0.9.0", features = ["macros"] }
+unic-langid = { workspace = true, features = ["macros"] }
 thiserror = "1.0.58"
 tera = { version = "1.15.0", optional = true, default-features = false }
 heck = "0.4.0"
-ignore = { version = "0.4.18", optional = true }
-flume = { version = "0.11.0", default-features = false }
+ignore = { workspace = true, optional = true  }
+flume = { workspace = true }
 log = "0.4.14"
 fluent-template-macros = { path = "./macros", optional = true, version = "0.9.2" }
-once_cell = "1.10.0"
+once_cell = { workspace = true }
 arc-swap = "1.5.0"
 intl-memoizer = "0.5.1"
-walkdir = { version = "2.3.3", optional = true }
+walkdir = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,12 +48,12 @@ handlebars = { version = "5", optional = true }
 fluent = "0.16"
 fluent-bundle = "0.15.2"
 fluent-syntax = "0.11"
-fluent-langneg = "0.13"
+fluent-langneg = "0.14"
 serde_json = "1.0.79"
 unic-langid = { workspace = true, features = ["macros"] }
 thiserror = "1.0.58"
 tera = { version = "1.15.0", optional = true, default-features = false }
-heck = "0.4.0"
+heck = "0.5.0"
 ignore = { workspace = true, optional = true  }
 flume = { workspace = true }
 log = "0.4.14"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -23,8 +23,8 @@ default = ["ignore"]
 quote = "1.0.15"
 syn = { version = "2.0", features = ["full"] }
 proc-macro2 = "1.0.36"
-once_cell = "1.10.0"
-ignore = { version = "0.4.16", optional = true }
-flume = { version = "0.10.12", default-features = false }
-unic-langid = "0.9.0"
-walkdir = { version = "2.3.3", optional = true }
+once_cell = { workspace = true }
+ignore = { workspace = true, optional = true }
+flume = { workspace = true }
+unic-langid = { workspace = true }
+walkdir = { workspace = true, optional = true }


### PR DESCRIPTION
Depends on https://github.com/XAMPPRocky/fluent-templates/pull/64.