### PR TITLE
chore: Bump `heck` to `v0.5.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ serde_json = "1.0.79"
 unic-langid = { workspace = true, features = ["macros"] }
 thiserror = "1.0.58"
 tera = { version = "1.15.0", optional = true, default-features = false }
-heck = "0.4.0"
+heck = "0.5.0"
 ignore = { workspace = true, optional = true  }
 flume = { workspace = true }
 log = "0.4.14"


### PR DESCRIPTION
Welp, I know I just "pressured" you into a quick release, and now, it turns out that `heck` is duplicated in Ruffle as well: https://github.com/ruffle-rs/ruffle/actions/runs/8783163213/job/24098750742#step:5:806
I should have paid more attention...

So, as per https://github.com/XAMPPRocky/fluent-templates/pull/65#issuecomment-2061050769, here's my `heck` bumper PR.

I'm really sorry for this "spam", I hope you don't mind frequent releases that much. O.O