### PR TITLE
Make `fallback` fields of `StaticLoader` and `ArcLoader` public

### DIFF
--- a/src/loader/arc_loader.rs
+++ b/src/loader/arc_loader.rs
@@ -101,7 +101,7 @@ impl<'a, 'b> ArcLoaderBuilder<'a, 'b> {
 /// ```
 pub struct ArcLoader {
     bundles: HashMap<LanguageIdentifier, FluentBundle<Arc<FluentResource>>>,
-    fallback: LanguageIdentifier,
+    pub fallback: LanguageIdentifier,
     fallbacks: HashMap<LanguageIdentifier, Vec<LanguageIdentifier>>,
 }
 

--- a/src/loader/arc_loader.rs
+++ b/src/loader/arc_loader.rs
@@ -101,7 +101,7 @@ impl<'a, 'b> ArcLoaderBuilder<'a, 'b> {
 /// ```
 pub struct ArcLoader {
     bundles: HashMap<LanguageIdentifier, FluentBundle<Arc<FluentResource>>>,
-    pub fallback: LanguageIdentifier,
+    fallback: LanguageIdentifier,
     fallbacks: HashMap<LanguageIdentifier, Vec<LanguageIdentifier>>,
 }
 
@@ -190,5 +190,10 @@ impl ArcLoader {
             text_id,
             args,
         )
+    }
+
+    /// Return the fallback language
+    pub fn fallback(&self) -> &LanguageIdentifier {
+        &self.fallback
     }
 }

--- a/src/loader/static_loader.rs
+++ b/src/loader/static_loader.rs
@@ -12,7 +12,7 @@ pub use unic_langid::LanguageIdentifier;
 pub struct StaticLoader {
     bundles: &'static HashMap<LanguageIdentifier, FluentBundle<&'static FluentResource>>,
     fallbacks: &'static HashMap<LanguageIdentifier, Vec<LanguageIdentifier>>,
-    pub fallback: LanguageIdentifier,
+    fallback: LanguageIdentifier,
 }
 
 impl StaticLoader {
@@ -52,6 +52,11 @@ impl StaticLoader {
         args: Option<&HashMap<S, FluentValue>>,
     ) -> Option<String> {
         super::shared::lookup_no_default_fallback(self.bundles, self.fallbacks, lang, text_id, args)
+    }
+
+    /// Return the fallback language
+    pub fn fallback(&self) -> &LanguageIdentifier {
+        &self.fallback
     }
 }
 

--- a/src/loader/static_loader.rs
+++ b/src/loader/static_loader.rs
@@ -12,7 +12,7 @@ pub use unic_langid::LanguageIdentifier;
 pub struct StaticLoader {
     bundles: &'static HashMap<LanguageIdentifier, FluentBundle<&'static FluentResource>>,
     fallbacks: &'static HashMap<LanguageIdentifier, Vec<LanguageIdentifier>>,
-    fallback: LanguageIdentifier,
+    pub fallback: LanguageIdentifier,
 }
 
 impl StaticLoader {


### PR DESCRIPTION
Currently, there is no way to get the fallback language previously defined at the initialization of the first-party loaders. This is especially awkard for the `StaticLoader` because is built from a macro that doesn't allows to set the fallback language from the output of another macro nor a dynamic string.