### PR TITLE
Make `flume` dependency optional and cleanup features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,9 +20,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, macos, windows]
-        feature: [handlebars, tera]
+        third-party-integration-feature: [handlebars, tera]
+        file-walker-feature: [walkdir, ignore]
     steps:
       - uses: actions/checkout@v2
       - run: |
-          cargo build --features ${{ matrix.feature }}
-          cargo test --features ${{ matrix.feature }} --verbose
+          cargo build --features ${{ matrix.third-party-integration-feature }},${{ matrix.file-walker-feature }}
+          cargo test --verbose --features ${{ matrix.third-party-integration-feature }},${{ matrix.file-walker-feature }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,10 @@ all-features = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
-default = ["macros", "use-ignore"]
+default = ["macros", "ignore"]
 macros = ["fluent-template-macros"]
-use-ignore = ["ignore", "fluent-template-macros/ignore"]
+ignore = ["dep:ignore", "fluent-template-macros/ignore", "dep:flume", "dep:log"]
+walkdir = ["dep:walkdir", "fluent-template-macros/walkdir", "dep:log"]
 
 [dependencies]
 handlebars = { version = "5", optional = true }
@@ -54,9 +55,9 @@ unic-langid = { workspace = true, features = ["macros"] }
 thiserror = "1.0.58"
 tera = { version = "1.15.0", optional = true, default-features = false }
 heck = "0.5.0"
-ignore = { workspace = true, optional = true  }
-flume = { workspace = true }
-log = "0.4.14"
+ignore = { workspace = true, optional = true }
+flume = { workspace = true, optional = true }
+log = { version = "0.4", optional = true }
 fluent-template-macros = { path = "./macros", optional = true, version = "0.9.4" }
 once_cell = { workspace = true }
 arc-swap = "1.5.0"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -17,7 +17,9 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["ignore"]
+default = []
+ignore = ["dep:ignore", "dep:flume"]
+walkdir = ["dep:walkdir"]
 
 [dependencies]
 quote = "1.0.15"
@@ -25,6 +27,6 @@ syn = { version = "2.0", features = ["full"] }
 proc-macro2 = "1.0.36"
 once_cell = { workspace = true }
 ignore = { workspace = true, optional = true }
-flume = { workspace = true }
+flume = { workspace = true, optional = true }
 unic-langid = { workspace = true }
 walkdir = { workspace = true, optional = true }

--- a/src/loader/shared.rs
+++ b/src/loader/shared.rs
@@ -12,7 +12,8 @@ pub fn lookup_single_language<T: AsRef<str>, R: Borrow<FluentResource>>(
     text_id: &str,
     args: Option<&HashMap<T, FluentValue>>,
 ) -> Result<String, LookupError> {
-    let bundle = bundles.get(lang)
+    let bundle = bundles
+        .get(lang)
         .ok_or_else(|| LookupError::LangNotLoaded(lang.clone()))?;
 
     let mut errors = Vec::new();
@@ -30,7 +31,8 @@ pub fn lookup_single_language<T: AsRef<str>, R: Borrow<FluentResource>>(
             })?
             .value()
     } else {
-        bundle.get_message(text_id)
+        bundle
+            .get_message(text_id)
             .ok_or_else(message_retrieve_error)?
             .value()
             .ok_or_else(message_retrieve_error)?


### PR DESCRIPTION
- Rename `use-ignore` feature by `ignore` to conform with macros crate. Let me know if the name `use-ignore` is preffered.
- Change `ignore` implicit feature name by `dep:ignore`. Note that `dep:` syntax is available starting from Rust v1.60 and MSRV for fluent-templates is v1.70.
- Make `flume` and `log` dependencies optional by refactoring file walkers. The dependency `flume` only is needed when using `ignore`.
- Add `walkdir` feature.