### PR TITLE
Relax dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,11 @@ keywords = ["handlebars", "tera", "fluent", "internationalization", "localizatio
 categories = ["internationalization", "localization", "template-engine"]
 
 [workspace.dependencies]
-unic-langid = "0.9.0"
-ignore = "0.4.18"
-flume = { version = "0.11.0", default-features = false }
-once_cell = "1.10.0"
-walkdir = "2.3.3"
+unic-langid = "0.9"
+ignore = "0.4"
+flume = { version = "0.11", default-features = false }
+once_cell = "1.19"
+walkdir = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [package.metadata.docs.rs]
@@ -43,27 +43,27 @@ default = ["macros", "ignore"]
 macros = ["fluent-template-macros"]
 ignore = ["dep:ignore", "fluent-template-macros/ignore", "dep:flume", "dep:log"]
 walkdir = ["dep:walkdir", "fluent-template-macros/walkdir", "dep:log"]
+handlebars = ["dep:handlebars", "dep:serde_json"]
+tera = ["dep:tera", "dep:heck", "dep:serde_json"]
 
 [dependencies]
 handlebars = { version = "5", optional = true }
 fluent = "0.16"
-fluent-bundle = "0.15.2"
+fluent-bundle = "0.15"
 fluent-syntax = "0.11"
 fluent-langneg = "0.13"
-serde_json = "1.0.79"
+serde_json = { version = "1", optional = true }
 unic-langid = { workspace = true, features = ["macros"] }
-thiserror = "1.0.58"
-tera = { version = "1.15.0", optional = true, default-features = false }
-heck = "0.5.0"
+thiserror = "1"
+tera = { version = "1.15", optional = true, default-features = false }
+heck = { version = "0.5", optional = true }
 ignore = { workspace = true, optional = true }
 flume = { workspace = true, optional = true }
 log = { version = "0.4", optional = true }
 fluent-template-macros = { path = "./macros", optional = true, version = "0.9.4" }
 once_cell = { workspace = true }
-arc-swap = "1.5.0"
-intl-memoizer = "0.5.1"
+intl-memoizer = "0.5"
 walkdir = { workspace = true, optional = true }
 
 [dev-dependencies]
-tempfile = "3.3.0"
-getrandom = { version = "0.2.0", features = ["js"] }
+tempfile = "3.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,8 +336,6 @@ pub use fluent_template_macros::static_loader;
 pub use unic_langid::LanguageIdentifier;
 
 #[doc(hidden)]
-pub use arc_swap;
-#[doc(hidden)]
 pub use once_cell;
 
 /// A convenience `Result` type that defaults to `error::Loader`.

--- a/tests/template.rs
+++ b/tests/template.rs
@@ -33,12 +33,11 @@ macro_rules! generate_tests {
     ($(fn $locale_test_fn:ident ($template_engine:ident, $locale:expr) {
         $($assert_macro:ident ! ( $lhs:expr , $rhs:expr ) );* $(;)?
     })+) => {
-        use serde_json::json;
         use fluent_templates::*;
         $(
             #[test]
             fn $locale_test_fn() {
-                let data = json!({"lang": $locale});
+                let data = serde_json::json!({"lang": $locale});
 
                 #[cfg(feature = "handlebars")]
                 if stringify!($template_engine) == "handlebars" {


### PR DESCRIPTION
- As fluent-templates is a library, it makes sense to relax dependencies as far as possible without incurring in unexpected breaking changes, so the consumers of the library can upgrade their dependencies deduplicating versions.
- Add `tera` and `handlebars` features.
- Make `serde_json` dependency optional because is only used along with `tera` and `handlebars`.
- Make `heck` dependency optional because is only used along with `tera`.
- Drop `arc_swap` dependency as is not used.
- Drop `getrandom` development dependency as is not used.
- Bump `once_cell` dependency to lastest minor (MSRV is 1.60).