### PR TITLE
[chore] Replace once_cell Lazy with standard lib LazyLock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Other
+
+- [**breaking**] Remove dependency on `once_cell` and replace `once_cell::sync::Lazy` with `std::sync::LazyLock`
+
 ## [0.11.0](https://github.com/XAMPPRocky/fluent-templates/compare/fluent-templates-v0.10.1...fluent-templates-v0.11.0) - 2024-09-22
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ categories = ["internationalization", "localization", "template-engine"]
 unic-langid = { version = "0.9", features = ["macros"] }
 ignore = "0.4"
 flume = { version = "0.11", default-features = false }
-once_cell = "1.19"
 walkdir = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -66,7 +65,6 @@ ignore = { workspace = true, optional = true }
 flume = { workspace = true, optional = true }
 log = { version = "0.4", optional = true }
 fluent-template-macros = { path = "./macros", optional = true, version = "0.11.0" }
-once_cell = { workspace = true }
 intl-memoizer = "0.5"
 walkdir = { workspace = true, optional = true }
 

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ fluent_templates::static_loader! {
 You can also modify each `FluentBundle` on initialisation to be able to
 change configuration or add resources from Rust.
 ```rust
+use std::sync::LazyLock;
 use fluent_bundle::FluentResource;
 use fluent_templates::static_loader;
-use once_cell::sync::Lazy;
 
 static_loader! {
     // Declare our `StaticLoader` named `LOCALES`.
@@ -73,7 +73,7 @@ static_loader! {
             // `FluentResource`s need to be either `&'static` or behind an
             // `Arc` it's recommended you use lazily initialised
             // static variables.
-            static CRATE_VERSION_FTL: Lazy<FluentResource> = Lazy::new(|| {
+            static CRATE_VERSION_FTL: LazyLock<FluentResource> = LazyLock::new(|| {
                 let ftl_string = String::from(
                     concat!("-crate-version = {}", env!("CARGO_PKG_VERSION"))
                 );

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -25,7 +25,6 @@ walkdir = ["dep:walkdir"]
 quote = "1.0.15"
 syn = { version = "2.0", features = ["full"] }
 proc-macro2 = "1.0.36"
-once_cell = { workspace = true }
 ignore = { workspace = true, optional = true }
 flume = { workspace = true, optional = true }
 unic-langid = { workspace = true }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -190,7 +190,7 @@ pub fn static_loader(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
         ..
     } = parse_macro_input!(input as StaticLoader);
     let CRATE_NAME: TokenStream = quote!(fluent_templates);
-    let LAZY: TokenStream = quote!(#CRATE_NAME::once_cell::sync::Lazy);
+    let LAZY: TokenStream = quote!(std::sync::LazyLock);
     let LANGUAGE_IDENTIFIER: TokenStream = quote!(#CRATE_NAME::loader::LanguageIdentifier);
     let FLUENT_BUNDLE: TokenStream = quote!(#CRATE_NAME::FluentBundle);
     let FLUENT_RESOURCE: TokenStream = quote!(#CRATE_NAME::fluent_bundle::FluentResource);
@@ -209,7 +209,10 @@ pub fn static_loader(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
     };
 
     let fallback_language_value = fallback_language.value();
-    if !fallback_language_value.parse::<unic_langid::LanguageIdentifier>().is_ok() {
+    if !fallback_language_value
+        .parse::<unic_langid::LanguageIdentifier>()
+        .is_ok()
+    {
         return syn::Error::new(
             fallback_language.span(),
             format!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,9 +49,9 @@
 //! You can also modify each `FluentBundle` on initialisation to be able to
 //! change configuration or add resources from Rust.
 //! ```
+//! use std::sync::LazyLock;
 //! use fluent_bundle::FluentResource;
 //! use fluent_templates::static_loader;
-//! use once_cell::sync::Lazy;
 //!
 //! static_loader! {
 //!     // Declare our `StaticLoader` named `LOCALES`.
@@ -68,7 +68,7 @@
 //!             // `FluentResource`s need to be either `&'static` or behind an
 //!             // `Arc` it's recommended you use lazily initialised
 //!             // static variables.
-//!             static CRATE_VERSION_FTL: Lazy<FluentResource> = Lazy::new(|| {
+//!             static CRATE_VERSION_FTL: LazyLock<FluentResource> = LazyLock::new(|| {
 //!                 let ftl_string = String::from(
 //!                     concat!("-crate-version = {}", env!("CARGO_PKG_VERSION"))
 //!                 );
@@ -336,9 +336,6 @@ pub use fluent_template_macros::static_loader;
 #[cfg(feature = "macros")]
 pub use unic_langid::langid;
 pub use unic_langid::LanguageIdentifier;
-
-#[doc(hidden)]
-pub use once_cell;
 
 /// A convenience `Result` type that defaults to `error::Loader`.
 pub type Result<T, E = error::LoaderError> = std::result::Result<T, E>;


### PR DESCRIPTION
Rust started supporting the functionality of the `once_cell` crate some time earlier this year, making it unnecessary.