### PR TITLE
deps: Bump Fluent crates to latest minor releases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,8 @@ tera = ["dep:tera", "dep:heck", "dep:serde_json"]
 
 [dependencies]
 handlebars = { version = "6", optional = true }
-fluent-bundle = "0.15"
-fluent-syntax = "0.11"
+fluent-bundle = "0.16"
+fluent-syntax = "0.12"
 fluent-langneg = "0.13"
 serde_json = { version = "1", optional = true }
 unic-langid = { workspace = true, features = ["macros"] }


### PR DESCRIPTION
I just released new versions of all the Project Fluent crates. Most of them were patch level, but these two were both minor level (breaking for us since we're still basically using zero-ver instead of semver). The breaking changes don't affect this project at all, so just bumping them looks fine.
