### PR TITLE
style: improve the error messages for unknown localizations

### DIFF
--- a/src/loader/arc_loader.rs
+++ b/src/loader/arc_loader.rs
@@ -124,7 +124,7 @@ impl super::Loader for ArcLoader {
                 return val;
             }
         }
-        format!("Unknown localization {text_id}")
+        format!("Unknown localization key: {text_id:?}")
     }
 
     // Traverse the fallback chain,

--- a/src/loader/multi_loader.rs
+++ b/src/loader/multi_loader.rs
@@ -107,7 +107,7 @@ impl crate::Loader for MultiLoader {
                 return text;
             }
         }
-        format!("Unknown localization {text_id}")
+        format!("Unknown localization key: {text_id:?}")
     }
 
     fn try_lookup_complete(

--- a/src/loader/static_loader.rs
+++ b/src/loader/static_loader.rs
@@ -80,7 +80,7 @@ impl super::Loader for StaticLoader {
                 return val;
             }
         }
-        format!("Unknown localization {text_id}")
+        format!("Unknown localization key: {text_id:?}")
     }
 
     // Traverse the fallback chain,


### PR DESCRIPTION
In the case where `nonexistent-key` does not exist in the loader:

Before:

> Unknown localization nonexistent-key

After:

> Unknown localization key: "nonexistent-key"

Just a small cosmetic change :)
