### PR TITLE
Build function returns proper error type

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use unic_langid::LanguageIdentifier;
+use unic_langid::{LanguageIdentifier, LanguageIdentifierError};
 
 /// Errors that can occur when loading or parsing fluent resources.
 #[derive(Debug, thiserror::Error)]
@@ -25,6 +25,13 @@ pub enum LoaderError {
     FluentBundle {
         /// The original bundle errors
         errors: Vec<fluent_bundle::FluentError>,
+    },
+    /// A locale directory was not a valid language identifier.
+    #[error("Error parsing LanguageIdentifier\n: {}", source)]
+    InvalidLanguageId {
+        /// The original parse error
+        #[from]
+        source: LanguageIdentifierError,
     },
 }
 


### PR DESCRIPTION
The `build` function returns the crate error instead of `Box<dyn std::error::Error>`.

I added a new variant to hold a new error type.

In the error display impl, the `\n` is in a weird place, but I put it in the same place anyway. Let me know if it was a mistake.