### PR TITLE
Use the new tera 2.1 version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,8 +59,7 @@ fluent-langneg = "0.13"
 serde_json = { version = "1", optional = true }
 unic-langid = { workspace = true, features = ["macros"] }
 thiserror = "2"
-tera = { git = "https://github.com/Keats/tera.git", rev = "ba36f89220aa7253da2e643f24479e452d8fde72", optional = true, default-features = false }
-# tera = { version = "2", optional = true, default-features = false }
+tera = { version = "2.1", optional = true, default-features = false }
 heck = { version = "0.5", optional = true }
 ignore = { workspace = true, optional = true }
 flume = { workspace = true, optional = true }


### PR DESCRIPTION
linked to https://github.com/XAMPPRocky/fluent-templates/pull/108

The version 2.1 has been published to crates.io, we can use it instead of the git dependency.

maybe this can be merged before the 0.15.0 release ? https://github.com/XAMPPRocky/fluent-templates/pull/109