### PR TITLE
macros: Walk the locales directory in a defined order

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -129,7 +129,7 @@ pub(crate) fn read_from_dir<P: AsRef<Path>>(path: P) -> Vec<String> {
     compile_error!("one of the features `ignore` or `walkdir` must be enabled.");
 
     #[cfg(feature = "ignore")]
-    {
+    let mut paths: Vec<String> = {
         let (tx, rx) = flume::unbounded();
 
         ignore::WalkBuilder::new(path)
@@ -151,17 +151,20 @@ pub(crate) fn read_from_dir<P: AsRef<Path>>(path: P) -> Vec<String> {
             });
 
         rx.drain().collect()
-    }
+    };
 
     #[cfg(all(not(feature = "ignore"), feature = "walkdir"))]
-    walkdir::WalkDir::new(path)
+    let mut paths: Vec<String> = walkdir::WalkDir::new(path)
         .follow_links(true)
         .into_iter()
         .filter_map(|e| e.ok())
         .filter(|e| e.file_type().is_file())
         .filter(|e| e.path().extension().map_or(false, |e| e == "ftl"))
         .map(|e| e.path().display().to_string())
-        .collect()
+        .collect();
+
+    paths.sort(); // for reproducible builds
+    paths
 }
 
 /// Loads all of your fluent resources at compile time as `&'static str`s and


### PR DESCRIPTION
While debugging variations in our (openSUSE) ruffle-0.4.1 package build results, I stumbled upon an issue in `fluent-template-macros` and tested that this fix helps.

**Problem**:
`read_from_dir` returns the `.ftl` paths in whatever order the walker produced them, and `static_loader!` turns that list straight into the `include_str!` arguments of the generated resource map. The list is therefore part of the macro expansion, and neither backend gives a defined order for it:

* with the default `ignore` backend the walk is `build_parallel()`, so which file lands in the channel first depends on thread scheduling and the order changes from one compilation to the next;
* with the `walkdir` backend it is readdir order, which is stable on a given directory but arbitrary, and does not agree with the `ignore` backend.

The sort added in "only depend on the filenames and the file contents" does not cover this. It sorts the `(locale, files)` pairs, so the locales come out in a defined order, but the file list inside each locale keeps the walker's order.

The visible effect is that a crate using `static_loader!` compiles to a different binary every time whenever a locale has more than one `.ftl` file: the localisation blobs are laid out in a different order, and everything after them moves. This came up while trying to build the openSUSE ruffle package reproducibly - ruffle has 17 `.ftl` files per locale and 30 locales, and its desktop binary differed on every rebuild for this reason alone.

**Solution**:
Sort the paths before returning them.

Note: please give this a thorough review as I am neither experienced with rust nor fluent-templates.

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).